### PR TITLE
Yeet header panel as well

### DIFF
--- a/include/UI/ViewControllers/LeaderboardNavigationButtonsController.hpp
+++ b/include/UI/ViewControllers/LeaderboardNavigationButtonsController.hpp
@@ -25,7 +25,9 @@ DECLARE_CLASS_CODEGEN_INTERFACES(LeaderboardCore::UI::ViewControllers, Leaderboa
     DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::UI::Button*, _rightButton);
 
     DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Transform*, _containerTransform);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Transform*, _headerPanelTransform);
     DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Vector3, _containerPosition);
+    DECLARE_INSTANCE_FIELD_PRIVATE(UnityEngine::Vector3, _headerPanelPosition);
     DECLARE_INSTANCE_FIELD_PRIVATE(bool, _leaderboardLoaded);
     DECLARE_INSTANCE_FIELD_PRIVATE(GlobalNamespace::IPreviewBeatmapLevel*, _selectedLevel);
     DECLARE_INSTANCE_FIELD_PRIVATE(int, _currentIndex);

--- a/src/UI/ViewControllers/LeaderboardNavigationButtonsController.cpp
+++ b/src/UI/ViewControllers/LeaderboardNavigationButtonsController.cpp
@@ -82,6 +82,8 @@ namespace LeaderboardCore::UI::ViewControllers {
         if (!_containerTransform || !_containerTransform->m_CachedPtr.m_value) {
             _containerTransform = _platformLeaderboardViewController->get_transform()->Find("Container");
             _containerPosition = _containerTransform->get_localPosition();
+            _headerPanelTransform = _platformLeaderboardViewController->get_transform()->Find("HeaderPanel");
+            _headerPanelPosition = _containerTransform->get_localPosition();
             OnLeaderboardLoaded(true);
         }
     }
@@ -154,6 +156,7 @@ namespace LeaderboardCore::UI::ViewControllers {
         if (_containerTransform && _containerTransform->m_CachedPtr.m_value) {
             DEBUG("YeetDefault");
             _containerTransform->set_localPosition({-999, -999, -999});
+            _headerPanelTransform->set_localPosition({-999, -999, -999});
         }
     }
 
@@ -161,6 +164,7 @@ namespace LeaderboardCore::UI::ViewControllers {
         if (_containerTransform && _containerTransform->m_CachedPtr.m_value) {
             DEBUG("UnYeetDefault");
             _containerTransform->set_localPosition(_containerPosition);
+            _headerPanelTransform->set_localPosition(_headerPanelPosition);
         }
     }
 

--- a/src/UI/ViewControllers/LeaderboardNavigationButtonsController.cpp
+++ b/src/UI/ViewControllers/LeaderboardNavigationButtonsController.cpp
@@ -83,7 +83,7 @@ namespace LeaderboardCore::UI::ViewControllers {
             _containerTransform = _platformLeaderboardViewController->get_transform()->Find("Container");
             _containerPosition = _containerTransform->get_localPosition();
             _headerPanelTransform = _platformLeaderboardViewController->get_transform()->Find("HeaderPanel");
-            _headerPanelPosition = _containerTransform->get_localPosition();
+            _headerPanelPosition = _headerPanelTransform->get_localPosition();
             OnLeaderboardLoaded(true);
         }
     }


### PR DESCRIPTION
Just like the Container of the original leaderboard, this also yeets the header above the highscores